### PR TITLE
More optimisations around empty nodes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeDag"
 uuid = "91963e24-6e66-4132-aeb8-436d9f37dbc7"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.17"
+version = "0.1.19"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeDag"
 uuid = "91963e24-6e66-4132-aeb8-436d9f37dbc7"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.19"
+version = "0.1.18"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/reference/creating_ops.md
+++ b/docs/src/reference/creating_ops.md
@@ -25,6 +25,14 @@ The most general way to create an op is to create a structure that inherits from
 One must use this to implement source nodes, but in other cases it is typically preferable to use [Standard alignment behaviour](@ref).
 This is because there are number of rules that must be adhered to when implementing [`TimeDag.run_node!`](@ref), as noted in its docstring. 
 
+!!! warning
+    Some care must be taken when implementing `==` for a new `NodeOp`.
+    We require that `==` means "produce identical output for the same inputs".
+    For example, two `NodeOp`s must never compare equal if they have different [`value_type`](@ref)s.
+
+    Failure to adhere to this will cause confusing behaviour in the [Identity map](@ref). 
+    This is because, if calling [`TimeDag.obtain_node`](@ref), it might think the node already exists, even though the `NodeOp`s aren't truly equivalent.
+
 ### Example: stateless source
 Here is stateless source node, which is effectively a simplified [`iterdates`](@ref):
 

--- a/docs/src/reference/misc_ops.md
+++ b/docs/src/reference/misc_ops.md
@@ -19,3 +19,9 @@ Base.rand
 Base.filter
 Base.skipmissing
 ```
+
+## Type conversion
+
+```@docs
+convert_value
+```

--- a/docs/src/reference/misc_ops.md
+++ b/docs/src/reference/misc_ops.md
@@ -20,7 +20,7 @@ Base.filter
 Base.skipmissing
 ```
 
-## Type conversion
+## Type conversion
 
 ```@docs
 convert_value

--- a/src/TimeDag.jl
+++ b/src/TimeDag.jl
@@ -27,8 +27,10 @@ export block_node, constant, empty_node, iterdates, pulse, tea_file
 # Alignment nodes.
 export active_count, align, align_once, coalign, count_knots, first_knot, lag, right, left
 export prepend, throttle
+# Type conversion
+export convert_value
 # Other nodes
-export history, ema
+export ema, history
 # Evaluation & other utilities.
 export evaluate, value_type
 
@@ -55,6 +57,7 @@ include("ops/window.jl")  # Common stuff for windowed ops.
 include("ops/align.jl")
 include("ops/array.jl")
 include("ops/conditional.jl")
+include("ops/conversion.jl")
 include("ops/history.jl")
 include("ops/lagging.jl")
 include("ops/random.jl")

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -115,7 +115,7 @@ function obtain_node(
             (A == UnionAlignment || (A == LeftAlignment && _is_constant(first(parents))))
         )
             # Replace empty inputs with intial values and propagate.
-            constant(_propagate_constant_value(op, _get_constant_inputs(parents, op)))
+            constant(T, _propagate_constant_value(op, _get_constant_inputs(parents, op)))
         else
             # In all other cases here the output will be empty.
             empty_node(T)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -49,8 +49,13 @@ end
 
 """
     constant(value) -> Node
+    constant(T, value) -> Node{T}
 
 Explicitly wrap `value` into a `TimeDag` constant node, regardless of its type.
+
+If `T` is provided, this allows creation of a node with a [`value_type`](@ref) that is a
+supertype of the type of the `value` — otherwise the constant node will always just use the
+concrete type of `value`.
 
 In many cases this isn't required, since many `TimeDag` functions which expect nodes will
 automatically wrap non-node arguments into a constant node.
@@ -60,3 +65,4 @@ automatically wrap non-node arguments into a constant node.
     likely not what you want to do.
 """
 constant(value::T) where {T} = obtain_node((), Constant(value))
+constant(::Type{T}, value) where {T} = obtain_node((), Constant{T}(value))

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -4,6 +4,8 @@ struct Constant{T} <: NodeOp{T}
 end
 
 Base.hash(x::Constant, h::UInt64) = hash(x.value, hash(:Constant, h))
+# Note that we do not permit Constant(1) == Constant(1.0), even though 1 == 1.0 in Julia.
+# This is by design — see discussion in the documentation in [`Low-level API`](@ref)
 function Base.:(==)(x::Constant{T}, y::Constant{T}) where {T}
     # Add short-circuit, in case Base.:(==)(::T, ::T) doesn't have one.
     x.value === y.value && return true

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -25,12 +25,12 @@ If all `parents` are constant nodes, and `op` has a well-defined operation on co
 inputs, we will immediately perform the computation and return a constant node wrapping the
 computed value.
 """
-function obtain_node(parents::NTuple{N,Node}, op::NodeOp) where {N}
+function obtain_node(parents::NTuple{N,Node}, op::NodeOp{T}) where {N,T}
     if !isempty(parents) && _can_propagate_constant(op) && all(_is_constant, parents)
         # Constant propagation, since all inputs are constants & the op supports it.
         # Note that `constant` does, itself, call through to `obtain_node`, so the node will
         # be correctly registered with the id_map.
-        return constant(_propagate_constant_value(op, parents))
+        return constant(T, _propagate_constant_value(op, parents))
     end
 
     return obtain_node!(global_identity_map(), parents, op)

--- a/src/ops/align.jl
+++ b/src/ops/align.jl
@@ -444,7 +444,9 @@ end
 Base.merge(x::Node) = x
 function Base.merge(x::Node, y::Node)
     x === y && return x
-    _is_constant(x) && _is_constant(y) && return y
     T = promote_type(value_type(x), value_type(y))
+    _is_empty(x) && return convert_value(T, y; upcast=true)
+    _is_empty(y) && return convert_value(T, x; upcast=true)
+    _is_constant(x) && _is_constant(y) && return convert_value(T, y; upcast=true)
     return obtain_node((x, y), Merge2{T}())
 end

--- a/src/ops/align.jl
+++ b/src/ops/align.jl
@@ -235,10 +235,11 @@ function prepend(x, y)
     x = _ensure_node(x)
     y = _ensure_node(y)
 
-    # Constant propagation.
-    _is_constant(x) && _is_constant(y) && return y
-
+    x === y && return x
     T = promote_type(value_type(x), value_type(y))
+    _is_empty(x) && return convert_value(T, y; upcast=true)
+    _is_empty(y) && return convert_value(T, x; upcast=true)
+    _is_constant(x) && _is_constant(y) && return convert_value(T, y; upcast=true)
     return obtain_node((x, y), Prepend{T}())
 end
 

--- a/src/ops/align.jl
+++ b/src/ops/align.jl
@@ -12,7 +12,10 @@ Construct a node that ticks according to `alignment` with the latest value of `x
 It is "left", in the sense of picking the left-hand of the two arguments `x` and `y`.
 """
 function left(x, y, alignment::Alignment=DEFAULT_ALIGNMENT; initial_values=nothing)
+    x = _ensure_node(x)
+    y = _ensure_node(y)
     x === y && return x
+    (_is_empty(x) || _is_empty(y)) && return empty_node(value_type(x))
     return apply(_left, x, y, alignment; initial_values)
 end
 
@@ -24,7 +27,10 @@ Construct a node that ticks according to `alignment` with the latest value of `y
 It is "right", in the sense of picking the right-hand of the two arguments `x` and `y`.
 """
 function right(x, y, alignment::Alignment=DEFAULT_ALIGNMENT; initial_values=nothing)
+    x = _ensure_node(x)
+    y = _ensure_node(y)
     x === y && return x
+    (_is_empty(x) || _is_empty(y)) && return empty_node(value_type(y))
     return apply(_right, x, y, alignment; initial_values)
 end
 
@@ -45,6 +51,9 @@ This means that the resulting node will tick at a subset of the times that `y` t
 function align_once(x, y)
     x = _ensure_node(x)
     y = _ensure_node(y)
+
+    (_is_empty(x) || _is_empty(y)) && return empty_node(value_type(x))
+    _is_constant(x) && _is_constant(y) && return x
 
     # Imagine the following scenario.
     #

--- a/src/ops/align.jl
+++ b/src/ops/align.jl
@@ -49,12 +49,6 @@ Similar to `align(x, y)`, except knots from `x` will be emitted at most once.
 This means that the resulting node will tick at a subset of the times that `y` ticks.
 """
 function align_once(x, y)
-    x = _ensure_node(x)
-    y = _ensure_node(y)
-
-    (_is_empty(x) || _is_empty(y)) && return empty_node(value_type(x))
-    _is_constant(x) && _is_constant(y) && return x
-
     # Imagine the following scenario.
     #
     # x: 1  2  3     4  5
@@ -293,6 +287,7 @@ The first knot encountered on the input will always be emitted.
 function throttle(x::Node, n::Integer)
     n > 0 || throw(ArgumentError("n should be positive, got $n"))
     n == 1 && return x
+    (_is_constant(x) || _is_empty(x)) && return x
     return obtain_node((x,), ThrottleKnots{value_type(x)}(n))
 end
 

--- a/src/ops/align.jl
+++ b/src/ops/align.jl
@@ -138,8 +138,8 @@ end
 Get a node which ticks with only the first knot of `x`, and then never ticks again.
 """
 function first_knot(node::Node{T}) where {T}
-    # This function should be idempotent for constant nodes.
-    _is_constant(node) && return node
+    # This function should be idempotent for constant & empty nodes.
+    (_is_constant(node) || _is_empty(node)) && return node
     return obtain_node((node,), FirstKnot{T}())
 end
 
@@ -150,6 +150,9 @@ Get a node of the number of the given `nodes` (at least one) which are active.
 """
 function active_count(x, x_rest...)
     nodes = map(_ensure_node, [x, x_rest...])
+
+    # Empty nodes are always inactive, so remove them from the set that we consider.
+    nodes = filter(!_is_empty, nodes)
 
     # Perform the same ordering optimisation that we use in coalign. This aims to give the
     # same node regardless of the order in which `nodes` were passed in.

--- a/src/ops/conditional.jl
+++ b/src/ops/conditional.jl
@@ -11,7 +11,12 @@ Obtain a node that removes knots for which `f(value)` is false.
 
 The [`value_type`](@ref) of the returned node is the same as that for the input `x`.
 """
-Base.filter(f::Function, x::Node) = obtain_node((x,), Filter{f,value_type(x)}())
+function Base.filter(f::Function, x::Node)
+    _is_empty(x) && return x
+    T = value_type(x)
+    _is_constant(x) && return f(value(x)) ? x : empty_node(T)
+    return obtain_node((x,), Filter{f,T}())
+end
 
 struct SkipMissing{T} <: UnaryNodeOp{T} end
 
@@ -38,5 +43,8 @@ function Base.skipmissing(x::Node)
         # There are provably no missing values in the input, so return the same node.
         return x
     end
-    return obtain_node((x,), SkipMissing{nonmissingtype(value_type(x))}())
+    T = nonmissingtype(value_type(x))
+    _is_constant(x) && return ismissing(value(x)) ? empty_node(T) : constant(T, value(x))
+    _is_empty(x) && return empty_node(T)
+    return obtain_node((x,), SkipMissing{T}())
 end

--- a/src/ops/conversion.jl
+++ b/src/ops/conversion.jl
@@ -11,16 +11,18 @@ See further discussion in the note.
     the [`value_type`](@ref) of the returned node might be a subtype of `T`.
 
     A concrete example:
-    ```julia
+    ```jldoctest
     julia> x = convert_value(Any, constant("hello"));
+
     julia> value_type(x)
     String
     ```
     Note that the same thing would happen if calling `convert(Any, "hello")`.
 
     However, if we set `upcast=true`:
-    ```julia
+    ```jldoctest
     julia> x = convert_value(Any, constant("hello"); upcast=true);
+
     julia> value_type(x)
     Any
     ```

--- a/src/ops/conversion.jl
+++ b/src/ops/conversion.jl
@@ -1,0 +1,43 @@
+"""
+    convert_value(T, x::Node[; upcast=false]) -> Node
+
+Convert the node `x` to value type `T`, possibly generating a new value.
+
+If and only if `upcast` is `true`, we will always upcast the result of the conversion to
+`T` — the value type of the resulting node will always be `T` in this case.
+
+!!! note
+    By default, this has similar semantics to `Base.convert`, which means that the
+    [`value_type`](@ref) of the returned node might be a subtype of `T`.
+
+    A concrete example:
+    ```julia
+    julia> x = convert_value(Any, constant("hello"));
+    julia> value_type(x)
+    String
+    ```
+    Note that the same thing would happen if calling `convert(Any, "hello")`.
+
+    However, if we set `upcast=true`:
+    ```julia
+    julia> x = convert_value(Any, constant("hello"); upcast=true);
+    julia> value_type(x)
+    Any
+    ```
+"""
+function convert_value(::Type{Out}, x::Node{In}; upcast::Bool=false) where {Out,In}
+    T_ = output_type(convert, Type{Out}, value_type(x))
+
+    # It should be the case that T_ <: Out, although they may not be equal. For example, if
+    # Out = Any, and value_type(x) == Int64, then we'll find that T_ == Int64.
+    # But if Out = Float64, then we'll get T_ = Float64.
+    T_ == Union{} && throw(ArgumentError("Cannot convert $In to type $Out"))
+
+    # It is possible that T_ <: T. The `upcast` argument determines to which value we
+    T_Out = upcast ? Out : T_
+
+    # If the conversion would be a no-op, then do not create a new node.
+    T_Out == In && return x
+
+    return apply(value -> convert(Out, value), x; out_type=T_Out)
+end

--- a/src/ops/conversion.jl
+++ b/src/ops/conversion.jl
@@ -33,7 +33,8 @@ function convert_value(::Type{Out}, x::Node{In}; upcast::Bool=false) where {Out,
     # But if Out = Float64, then we'll get T_ = Float64.
     T_ == Union{} && throw(ArgumentError("Cannot convert $In to type $Out"))
 
-    # It is possible that T_ <: T. The `upcast` argument determines to which value we
+    # It is possible that T_ <: Out. The `upcast` argument determines whether we should
+    # force use of `Out` rather than the subtype `T_`.
     T_Out = upcast ? Out : T_
 
     # If the conversion would be a no-op, then do not create a new node.

--- a/src/ops/conversion.jl
+++ b/src/ops/conversion.jl
@@ -1,14 +1,14 @@
 """
     convert_value(T, x::Node[; upcast=false]) -> Node
 
-Convert the node `x` to value type `T`, possibly generating a new value.
+Convert the values of node `x` to type `T`.
 
-If and only if `upcast` is `true`, we will always upcast the result of the conversion to
-`T` — the value type of the resulting node will always be `T` in this case.
+The value type of the resulting node is guaranteed to be `T` if and only if `upcast=true`.
+See further discussion in the note.
 
 !!! note
-    By default, this has similar semantics to `Base.convert`, which means that the
-    [`value_type`](@ref) of the returned node might be a subtype of `T`.
+    By default, `convert_value` has similar semantics to `Base.convert`, which means that
+    the [`value_type`](@ref) of the returned node might be a subtype of `T`.
 
     A concrete example:
     ```julia

--- a/test/constant.jl
+++ b/test/constant.jl
@@ -5,6 +5,9 @@
 
     @test TimeDag.Constant(1.0) != TimeDag.Constant(1)
     @test !isequal(TimeDag.Constant(1.0), TimeDag.Constant(1))
+
+    @test TimeDag.Constant(1) == TimeDag.Constant{Int64}(1)
+    @test TimeDag.Constant{Number}(1) != TimeDag.Constant{Int64}(1)
 end
 
 @testset "constant propagation" begin
@@ -21,6 +24,14 @@ end
     @test n1 - n2 === constant(-1)
 
     @test lag(n1, 2) === constant(1)
+end
+
+@testset "explicit type specification" begin
+    @test constant(Int64, 1) === constant(1)
+    n = constant(Number, 1)
+    @test n === constant(Number, 1)
+    @test value_type(n) == Number
+    @test_throws MethodError constant(String, 1)
 end
 
 @testset "evaluate" begin

--- a/test/constant.jl
+++ b/test/constant.jl
@@ -22,8 +22,6 @@ end
 
     @test n1 + n2 === constant(3)
     @test n1 - n2 === constant(-1)
-
-    @test lag(n1, 2) === constant(1)
 end
 
 @testset "explicit type specification" begin

--- a/test/ops/align.jl
+++ b/test/ops/align.jl
@@ -1,11 +1,19 @@
 @testset "right" begin
     _test_binary_op(right, (x, y) -> y)
-    @test right(n1, n1) === n1
+    for alignment in (LEFT, UNION, INTERSECT)
+        @test right(n1, n1, alignment) === n1
+        @test right(empty_node(Float64), n1, alignment) === empty_node(Int64)
+        @test right(n1, empty_node(Float64), alignment) === empty_node(Float64)
+    end
 end
 
 @testset "left" begin
     _test_binary_op(left, (x, y) -> x)
-    @test left(n1, n1) === n1
+    for alignment in (LEFT, UNION, INTERSECT)
+        @test left(n1, n1, alignment) === n1
+        @test left(empty_node(Float64), n1, alignment) === empty_node(Float64)
+        @test left(n1, empty_node(Float64), alignment) === empty_node(Int64)
+    end
 end
 
 @testset "align" begin
@@ -38,6 +46,10 @@ end
         DateTime(2000, 1, 5) => 8
     ])
     #! format:on
+
+    @test align_once(1, 2) === constant(1)
+    @test align_once(n1, empty_node(Float64)) === empty_node(Int64)
+    @test align_once(empty_node(Float64), n1) === empty_node(Float64)
 end
 
 @testset "coalign" begin

--- a/test/ops/align.jl
+++ b/test/ops/align.jl
@@ -120,7 +120,10 @@ end
     # The second argument should take over as soon as it is available. In the case that both
     # arguments are constants, that is immediately.
     @test prepend(1, 2) === constant(2)
-    @test prepend(1, "s") === constant("s")
+    @test prepend(1, 2.0) === constant(2.0)
+    @test prepend(1.0, 2) === constant(2.0)
+    @test prepend(constant(Number, 1), 2) === constant(Number, 2)
+    @test prepend(1, "s") === constant(Any, "s")
 
     # We should promote or widen types where applicable.
     @test value_type(prepend(1, n1)) == Int64
@@ -128,6 +131,7 @@ end
     @test value_type(prepend("s", n1)) == Any
     @test prepend(1, n2) === prepend(constant(1), n2)
     @test prepend(n1, n2) === prepend(n1, n2)
+    @test prepend(n1, n1) === n1
 
     @test _eval(prepend(42, n1)) == b1
     @test _eval(prepend(42, n2)) == Block([
@@ -152,6 +156,14 @@ end
         DateTime(2000, 1, 4) => 1,
         DateTime(2000, 1, 5) => 5,
     ])
+
+    # Test empty node prepending.
+    n_empty = empty_node(Int64)
+    @test prepend(n_empty, n1) === n1
+    @test prepend(n1, n_empty) === n1
+    @test prepend(n_empty, n_empty) === n_empty
+    @test prepend(empty_node(Float64), empty_node(Int64)) === empty_node(Float64)
+    @test prepend(empty_node(Float64), 1) === constant(1.0)
 end
 
 @testset "throttle" begin

--- a/test/ops/align.jl
+++ b/test/ops/align.jl
@@ -95,7 +95,7 @@ end
 @testset "first_knot" begin
     @test _eval(first_knot(n4)) == b4[1:1]
     @test _eval(first_knot(n_boolean)) == b_boolean[1:1]
-    @test _eval(empty_node(Float64)) == Block{Float64}()
+    @test first_knot(empty_node(Float64)) === empty_node(Float64)
     @test first_knot(constant(42.0)) === constant(42.0)
 end
 
@@ -110,6 +110,10 @@ end
     @test active_count(n1, n2, n3) === active_count(n2, n1, n3)
     @test active_count(n1, n2, n3) === active_count(n3, n1, n2)
     @test active_count(n1, n2, n3) === active_count(n3, n2, n1)
+
+    n_empty = empty_node(Int64)
+    @test active_count(n1, n2, n_empty) === active_count(n2, n1)
+    @test active_count(n1, n_empty, n2, n_empty, n3, n_empty) === active_count(n3, n2, n1)
 end
 
 @testset "prepend" begin
@@ -198,11 +202,11 @@ end
     @test merge(constant(1), constant(2), constant(3)) === constant(3)
 
     # Empty nodes should be skipped when merging.
-    empty = empty_node(Int64)
-    @test merge(empty) === empty
-    @test merge(constant(1), empty) === constant(1)
-    @test merge(empty, empty, constant(1), empty) === constant(1)
-    @test merge(empty, n2) === n2
+    n_empty = empty_node(Int64)
+    @test merge(n_empty) === n_empty
+    @test merge(constant(1), n_empty) === constant(1)
+    @test merge(n_empty, n_empty, constant(1), n_empty) === constant(1)
+    @test merge(n_empty, n2) === n2
 
     # If the times of the inputs are identically equal, we expect to not
     # allocate a new block in evaluation.

--- a/test/ops/align.jl
+++ b/test/ops/align.jl
@@ -183,17 +183,26 @@ end
     @test _eval(throttle(n4, 2)) == b4[1:2:end]
     @test _eval(throttle(n4, 3)) == b4[1:3:end]
     @test _eval(throttle(n4, 4)) == b4[1:4:end]
+
+    # Check for optimisation
+    @test throttle(constant(42), 1) === constant(42)
+    @test throttle(constant(42), 5) === constant(42)
+    @test throttle(empty_node(Float64), 5) === empty_node(Float64)
+    @test throttle(empty_node(String), 5) === empty_node(String)
 end
 
 @testset "count_knots" begin
     _expected_count_knots(b::Block) = Block(b.times, 1:length(b))
     @test count_knots(n1) === count_knots(n1)
     @test _eval(count_knots(42)) == Block([_T_START], [1])
+
     # Check for optimisation
     @test count_knots(42) === constant(1)
     @test _eval(count_knots(n1)) == _expected_count_knots(b1)
     @test _eval(count_knots(n4)) == _expected_count_knots(b4)
     @test _eval(count_knots(n_boolean)) == _expected_count_knots(b_boolean)
+    @test count_knots(empty_node(Float64)) === empty_node(Int64)
+    @test count_knots(empty_node(String)) === empty_node(Int64)
 end
 
 @testset "skip" begin

--- a/test/ops/conditional.jl
+++ b/test/ops/conditional.jl
@@ -12,6 +12,12 @@
         DateTime(2000, 1, 3) => 3,
         DateTime(2000, 1, 4) => 4,
     ])
+
+    # Optimisations
+    @test filter(>(0), constant(1)) === constant(1)
+    @test filter(>(0), constant(-1)) === empty_node(Int64)
+    @test filter(>(0), empty_node(Float64)) === empty_node(Float64)
+    @test filter(>(0), empty_node(Int64)) === empty_node(Int64)
 end
 
 @testset "skipmissing" begin
@@ -20,9 +26,14 @@ end
     @test value_type(n) == Int64
     @test n === skipmissing(n)
 
-    # Constant semantics.
-    @test constant(1) === skipmissing(constant(1))
-    @test skipmissing(constant(missing)).op isa TimeDag.SkipMissing
+    # Constant and empty semantics.
+    @test skipmissing(constant(1)) === constant(1)
+    @test skipmissing(constant(Union{Missing,Int64}, 1)) === constant(1)
+    @test skipmissing(constant(missing)) === empty_node(Union{})
+    @test skipmissing(constant(Union{Float64,Missing}, missing)) === empty_node(Float64)
+    @test skipmissing(empty_node(Float64)) === empty_node(Float64)
+    @test skipmissing(empty_node(Union{Float64,Missing})) === empty_node(Float64)
+    @test skipmissing(empty_node(Missing)) === empty_node(Union{})
 
     # Standard case.
     n = block_node(

--- a/test/ops/conversion.jl
+++ b/test/ops/conversion.jl
@@ -1,0 +1,20 @@
+@testset "convert_value" begin
+    n1_float = convert_value(Float64, n1)
+    @test value_type(n1_float) == Float64
+    @test convert_value(Int64, n1) === n1
+    @test convert_value(Float64, n1_float) === n1_float
+
+    @test_throws ArgumentError convert_value(String, n1)
+
+    # Supertypes that might not get converted.
+    @test value_type(convert_value(Any, n1)) == Int64
+    @test value_type(convert_value(Any, n1; upcast=false)) == Int64
+    @test value_type(convert_value(Any, n1; upcast=true)) == Any
+    @test value_type(convert_value(Number, n1; upcast=true)) == Number
+
+    @test convert_value(Float64, constant(1)) === constant(1.0)
+    @test convert_value(Float64, empty_node(Int64)) === empty_node(Float64)
+    @test convert_value(Number, constant(1)) === constant(Int64, 1)
+    @test convert_value(Number, constant(1); upcast=true) === constant(Number, 1)
+    @test convert_value(Number, empty_node(Int64); upcast=true) === empty_node(Number)
+end

--- a/test/ops/lagging.jl
+++ b/test/ops/lagging.jl
@@ -37,8 +37,10 @@ end
 
     @testset "constant" begin
         n = constant(42.0)
-        @test lag(n, 1) === n
-        @test lag(n, Hour(1)) === n
+        @test lag(n, 0) === n
+        @test lag(n, Hour(0)) === n
+        @test lag(n, 1) === empty_node(Float64)
+        @test lag(n, Hour(1)) === n  # Lagging a constant by a _time_ interval is a no-op.
     end
 
     @testset "general" begin

--- a/test/ops/simple.jl
+++ b/test/ops/simple.jl
@@ -43,14 +43,6 @@ const _UNARY_STUFF = [
         @test inv(inv(n1)) === n1
         @test !(!n_boolean) === n_boolean
     end
-
-    @testset "difference of DateTime" begin
-        block = Block(b4.times, b4.times)
-        n = block_node(block)
-        @test value_type(n) == DateTime
-        n_diff = n - n
-        @test value_type(n_diff) == Millisecond
-    end
 end
 
 # FIXME: really need extended tests (especially for dot) where we use vector inputs too.
@@ -62,5 +54,13 @@ const _BINARY_FUNCTIONS = [+, -, *, /, ^, min, max, >, <, >=, <=, dot]
             # Test evaluations with different alignments.
             _test_binary_op(f)
         end
+    end
+
+    @testset "difference of DateTime" begin
+        block = Block(b4.times, b4.times)
+        n = block_node(block)
+        @test value_type(n) == DateTime
+        n_diff = n - n
+        @test value_type(n_diff) == Millisecond
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ using TimeDag: duplicate, evaluate_until!, start_at
         @testset "array" begin include("ops/array.jl") end
         @testset "common" begin include("ops/common.jl") end
         @testset "conditional" begin include("ops/conditional.jl") end
+        @testset "conversion" begin include("ops/conversion.jl") end
         @testset "history" begin include("ops/history.jl") end
         @testset "lagging" begin include("ops/lagging.jl") end
         @testset "random" begin include("ops/random.jl") end


### PR DESCRIPTION
This also includes a few fixes to type promotion rules.

The starting point is to ensure that the type semantics of `Base.merge` for nodes matches that of the stdlib method for dictionaries. This necessitated the ability to create `constant` nodes with a value type a supertype of the type of their value (e.g. the node op `Constant{Number}(1)`).

Also useful was `convert_value`, which has semantics that match `Base.convert` by default. However it can also "upcast" results to abstract types if a keyword argument is specified — this functionality is used in improved versions of `merge` and `prepend`.