### PR TITLE
Fix bug in equivalence_classes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeDag"
 uuid = "91963e24-6e66-4132-aeb8-436d9f37dbc7"
 authors = ["Invenia Technical Computing Corporation", "Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.1.21"
+version = "0.1.22"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -917,9 +917,8 @@ relation `f : T × T → Bool`.
 
 Note that behaviour is undefined if `f` is non-transitive.
 """
-function equivalence_classes(
-    f::Function, x::Union{AbstractVector{T},Tuple{Vararg{T}}}
-) where {T}
+function equivalence_classes(f::Function, x)
+    T = eltype(x)
     result = Vector{Vector{T}}()
     isempty(x) && return result
 

--- a/test/alignment.jl
+++ b/test/alignment.jl
@@ -1,0 +1,16 @@
+@testset "equivalence_classes" begin
+    @test TimeDag.equivalence_classes(==, [1, 1, 2, 3, 3, 3]) == [[1, 1], [2], [3, 3, 3]]
+    @test TimeDag.equivalence_classes(==, (1, 1, 2, 3, 3, 3)) == [[1, 1], [2], [3, 3, 3]]
+
+    @test begin
+        TimeDag.equivalence_classes(
+            TimeDag._equal_times, [Block{Int64}(), Block{Float32}()]
+        ) == [[Block{Int64}()], [Block{Float32}()]]
+    end
+
+    @test begin
+        TimeDag.equivalence_classes(
+            TimeDag._equal_times, (Block{Int64}(), Block{Float32}())
+        ) == [[Block{Int64}()], [Block{Float32}()]]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ using TimeDag: duplicate, evaluate_until!, start_at
 
     include("common.jl")
 
+    @testset "alignment" begin include("alignment.jl") end
     @testset "block" begin include("block.jl") end
     @testset "constant" begin include("constant.jl") end
     @testset "empty" begin include("empty.jl") end


### PR DESCRIPTION
This fixes an error when `equivalence_classes` is given a tuple, which is what we depend on internally. Something about the `Tuple{Vararg{T}}` construction doesn't work properly, since we got strange runtime errors like `UndefVarError: T not defined` when running e.g.

```julia
TimeDag.equivalence_classes(==, (1, 2.0))
```